### PR TITLE
Add an authentication check to ensure we have a logged in user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ It also connects to Xcode's built-in MCP tools (via `xcrun mcpbridge`), giving C
 
 ## Installation
 
-You need [Node.js](https://nodejs.org) 25.6.0 or later and the GitHub Copilot CLI. [Install the Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/install-copilot-cli) and sign in before starting the server.
+You need [Node.js](https://nodejs.org) 25.6.0 or later and a GitHub Copilot subscription. Before starting the server, authenticate using one of the following methods (the Copilot CLI is bundled with the SDK, so you only need one of these for initial sign-in):
 
-Once done, you can install this server via:
+- [Install the Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/install-copilot-cli) and run `copilot login`
+- [Install the GitHub CLI](https://cli.github.com/) and run `gh auth login`
+- Set a `GITHUB_TOKEN` environment variable with a valid fine-grained Copilot access token
+
+Then install the server via:
 
 ```bash
 npm install -g xcode-copilot-server

--- a/src/copilot-service.ts
+++ b/src/copilot-service.ts
@@ -3,6 +3,7 @@ import {
   type CopilotSession,
   type SessionConfig,
   type ModelInfo,
+  type GetAuthStatusResponse,
 } from "@github/copilot-sdk";
 import type { LogLevel, Logger } from "./logger.js";
 
@@ -42,6 +43,10 @@ export class CopilotService {
     }
     this.sessionPromise = null;
     await this.client.stop();
+  }
+
+  async getAuthStatus(): Promise<GetAuthStatusResponse> {
+    return this.client.getAuthStatus();
   }
 
   async listModels(): Promise<ModelInfo[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,16 @@ async function main(): Promise<void> {
   await service.start();
   logger.info("Copilot CLI is up");
 
+  const auth = await service.getAuthStatus();
+  if (!auth.isAuthenticated) {
+    logger.error(
+      "Not authenticated. Sign in with the Copilot CLI (copilot login) or GitHub CLI (gh auth login), or set a GITHUB_TOKEN environment variable.",
+    );
+    await service.stop();
+    process.exit(1);
+  }
+  logger.info(`Authenticated as ${auth.login ?? "unknown"} (${auth.authType ?? "unknown"})`);
+
   const ctx: AppContext = { service, logger, config };
   const app = await createServer(ctx);
   await app.listen({ port, host: "127.0.0.1" });


### PR DESCRIPTION
This is needed otherwise the server will hang indefinitely since the CLI is running in headless mode and we can't do an interactive login at that point.